### PR TITLE
K8s ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you run into issues installing via `inspec plugin install train-kubernetes`, 
 
 * Try running `gem install train-kubernetes` before `inspec plugin install train-kubernetes`.
 * Ensure the `~/.inspec/plugins.json` has `"0.1.3"` and not `"= 0.1.3"` for the `version` value.  Modify it by hand if needed. 
-* Ensure you can cleanly install the `k8s-client` gem version `0.10.4` or greater.  e.g. `gem install k8s-client -v 0.10.4`
+* Ensure you can cleanly install the `k8s-client` gem version `0.10.4` or greater.  e.g. `gem install k8s-ruby`
 * Ensure that only one version of the `excon` gem is installed.  e.g. `gem list | grep excon`.  If you see two versions, `gem uninstall excon` and remove the older version.
 
 ## Reporting Issues

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you run into issues installing via `inspec plugin install train-kubernetes`, 
 
 * Try running `gem install train-kubernetes` before `inspec plugin install train-kubernetes`.
 * Ensure the `~/.inspec/plugins.json` has `"0.1.3"` and not `"= 0.1.3"` for the `version` value.  Modify it by hand if needed. 
-* Ensure you can cleanly install the `k8s-client` gem version `0.10.4` or greater.  e.g. `gem install k8s-ruby`
+* Ensure you can cleanly install the `k8s-ruby` gem version `0.10.4` or greater.  e.g. `gem install k8s-ruby -v 0.10.4`
 * Ensure that only one version of the `excon` gem is installed.  e.g. `gem list | grep excon`.  If you see two versions, `gem uninstall excon` and remove the older version.
 
 ## Reporting Issues

--- a/lib/train-kubernetes/connection.rb
+++ b/lib/train-kubernetes/connection.rb
@@ -1,5 +1,5 @@
 require 'train'
-require 'k8s-client'
+require 'k8s-ruby'
 require 'train-kubernetes/platform'
 
 module TrainPlugins


### PR DESCRIPTION
> Unfortunately the company Kontena.io went bankrupt at the end of the year 2019.

The repo has sense been forked and is now maintained at k8s-ruby.